### PR TITLE
[PORT-18][BUGFIX] Hide main body when nav links are visible in responsive mode.

### DIFF
--- a/src/app/App.css
+++ b/src/app/App.css
@@ -1,4 +1,7 @@
-.main-content {
-  max-width: var(--max-width);
-  margin: 0 auto;
+.mainSection {
+    @media(width <= 768px) {
+        &.displayNav {
+            display: none;
+        }
+    }
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,14 +1,28 @@
+import './App.css'
 import Navigation from "../components/navigation/navigation.tsx"
 import Hero from "../components/hero/hero.tsx"
+import {useState} from "react";
 
 const App = ()=> {
 
-  return (
-      <>
-        <Navigation />
-        <Hero />
-      </>
-  )
+    const [showNavList, setShowNavList] = useState(false)
+
+    const displayNavList = ()=> {
+        setShowNavList(true);
+    }
+
+    const hideNavList = () => {
+        setShowNavList(false);
+    }
+
+    return (
+        <>
+            <Navigation showNavList={showNavList} displayNavList={displayNavList} hideNavList={hideNavList} />
+            <section className={`mainSection ${showNavList ? "displayNav" : ""}`}>
+                <Hero />
+            </section>
+        </>
+    )
 }
 
 export default App

--- a/src/components/hero/Hero.css
+++ b/src/components/hero/Hero.css
@@ -55,7 +55,6 @@
         }
 
         .profile-copy {
-            padding: initial;
             padding: 20px 0;
         }
 

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -1,20 +1,20 @@
-import { useState } from "react"
+import { type FC } from "react"
 import "./Navigation.css"
 import hamburgerIcon from "../../assets/icons/hamburger.svg"
 import closeIcon from "../../assets/icons/close.svg"
 
-const Navigation = ()=> {
+interface NavigationProps {
+    showNavList: boolean,
+    hideNavList: () => void,
+    displayNavList: () => void,
+}
 
-    const [showNavList, setShowNavList] = useState(false)
-    
-    const displayNavList = ()=> {
-        setShowNavList(true);
-    }
-
-    const hideNavList = () => {
-        setShowNavList(false);
-    }
-
+const Navigation:FC<NavigationProps> =
+({
+    showNavList,
+    hideNavList,
+    displayNavList
+})=> {
     return (
         <section className="navigation-container">
             <div className="navigation">


### PR DESCRIPTION
Fixed bug where display nav links in response mode would show the main content. Now, the main content will not be displayed when nav links are visible.