### PR TITLE
Adding command in build step to automatically create 404.html file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && npm run build-github-route-page",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "build-github-route-page": "cp ./dist/index.html ./dist/404.html"
   },
   "dependencies": {
     "react": "^19.2.0",


### PR DESCRIPTION
1. Adding command in build step to automatically create 404.html file. That way, any changes to `index.html` should be reflected in 404.html when the project is rebuilt.
2. This is an attempt to set up browser routing in github. When navigating to a route, github will try to load the `index.html` in that route. Since none exists in a react SPA, it loads a 404.html. The idea is that by adding a 404.html which is a duplicate of index.html, the routing mechanism should kick in and display the correct component.